### PR TITLE
Removed slash that caused git checkout to fail

### DIFF
--- a/tutorial/Makefile
+++ b/tutorial/Makefile
@@ -25,7 +25,7 @@ help:
 clean:
 	-rm -rf _build/*
 
-html: _themes/
+html: _themes
 	mkdir -p _build/html _build/doctrees
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) _build/html
 	@echo


### PR DESCRIPTION
The sphinx docs will not build without removing this. Might also be necessary to get rid of the _themes directory, since the checkout will create it anyway.
